### PR TITLE
Refactor and improve highlighting

### DIFF
--- a/poki-uiua.css
+++ b/poki-uiua.css
@@ -3,10 +3,10 @@ i{display:none}
 html,body{height:100%}
 body{display:flex;flex-flow:column;margin:auto;max-width:max(85vw, 900px); font-size:16px;
   overflow:hidden;position:relative;color:#222;  content:"w";background:#ddd                   }  .w{background:#ddd;filter:invert(0)}
-@media(prefers-color-scheme:dark){body[class=""]{content:"g";background:#444;filter:invert(.85)} body[class=""] .emoji{filter:invert(1)}}
-.g{background:#444;filter:invert(.85)} .g .emoji{filter:invert(1)}
-@media(prefers-contrast:more)    {body[class=""]{content:"b";background:#222;filter:invert(1)} body[class=""] .emoji{filter:invert(1)} }
-.b{background:#222;filter:invert(1)} .b .emoji{filter:invert(1)}
+@media(prefers-color-scheme:dark){body[class=""]{content:"g";background:#444;filter:invert(.85)} body[class=""] .noinv{filter:invert(1)} body[class=""] .tk-s{color:#20f9fc}}
+.g{background:#444;filter:invert(.85)} .g .noinv{filter:invert(1)} .g .tk-s{color:#20f9fc}
+@media(prefers-contrast:more)    {body[class=""]{content:"b";background:#222;filter:invert(1)} body[class=""] .noinv{filter:invert(1)} }
+.b{background:#222;filter:invert(1)} .b .noinv{filter:invert(1)}
 .f{display:flex} .h{padding:0.5em}
 .o,#m{margin:0 0.35em} label{margin-left:0.35em}
 #q{flex:1;border:none;font-size:medium;margin-right:-1.5em} #x{margin-right:0.5em}
@@ -33,4 +33,4 @@ tr :nth-child(2){width: min(10vw, 50px)}
 tr :nth-child(3){width: 70%}
 tr :nth-child(4){width: min(20vw, 220px)}
 tr :nth-child(5){width: min(15vw, 150px)}
-.tk-n{color:#f08050}.tk-s{color:#20f9fc}.tk-mf{color:#95d16a}.tk-df{color:#54b0fc}.tk-mm{color:#f0c36f}.tk-dm{color:#cc6be9}
+.tk-n{color:#f08050}.tk-s{color:#1c9}.tk-mf{color:#95d16a}.tk-df{color:#54b0fc}.tk-mm{color:#f0c36f}.tk-dm{color:#cc6be9}

--- a/poki-uiua.js
+++ b/poki-uiua.js
@@ -1,34 +1,33 @@
 C = _ => F(history.replaceState({}, document.title, location.pathname + (q.value ? "?q=" + encodeURIComponent(q.value) : "")))
 F = _ => q.focus()
-tk = c => `<span class=\"emoji tk-${c}\">$&</span>`
-highlight = c => c .replace(/[=≠≤≥+\-×*÷◿∨ⁿ↧↥∠ℂ≍⊟⊂⊏⊡↯↙↘↻⤸▽⌕⦷∊⨂⊥⍤]|&(gt|lt);/g,tk`df`)
-    .replace(/(?<!\@)¯?[0-9.ηπτ∞]+/g,tk`n`).replace(/@(&.*?;|\\.|.)/g,tk`s`)
-    .replace(/[¬±¯⌵⨪√ₑ∿⌊⌈⁅⧻△⇡⊢⊣⇌♭¤⋯⍉⍆⍏⍖⊚◴⊛⧆□⋕]/g,tk`mf`)
-    .replace(/[˙˜⊙⋅⟜⊸⤙⤚◠◡∩∧\\≡⍚⊞⧅⧈⍥⊕⊜⧋◇∪⌅°⌝⍩⩜∂∫]|&sol;/g,tk`mm`)
-    .replace(/[⊃⊓⍜⍢⬚⨬⍣]/g,tk`dm`)
+highlight = c => 
+    c.replace(
+        /(?<s>@(&.*?;|\\.|.))|(?<n>¯?[0-9.ηπτ∞]+)|(?<mf>[¬±¯⌵⨪√ₑ∿⌊⌈⁅⧻△⇡⊢⊣⇌♭¤⋯⍉⍆⍏⍖⊚◴⊛⧆□⋕])|(?<df>[=≠≤≥+\-×*÷◿∨ⁿ↧↥∠ℂ≍⊟⊂⊏⊡↯↙↘↻⤸▽⌕⦷∊⨂⊥⍤]|&(gt|lt);)|(?<mm>[˙˜⊙⋅⟜⊸⤙⤚◠◡∩∧\/\\≡⍚⊞⧅⧈⍥⊕⊜⧋◇∪⌅°⌝⍩⩜∂∫])|(?<dm>[⊃⊓⍜⍢⬚⨬⍣])/g,
+        (m,...g)=>`<span class="noinv tk-${Object.entries(g.at(-1)).find(e=>e[1])[0]}">${m}</span>`
+    )
 I = _ => {
     var s = new URLSearchParams(location.search)
     b.className = 0 == s.get("w") ? "w" : 0 == s.get("b") ? "b" : ""
     um.href = "quiz?" + b.className
     fetch("table.tsv").then(d => d.text()).then(d => {
-        ps = d.replace(/[<>&'"/]/g, x => ({
+        ps = d.replace(/[<>&'"]/g, x => ({
             '<': '&lt;',
             '>': '&gt;',
             '&': '&amp;',
             "'": '&apos;',
             '"': '&quot;',
-            "/": "&sol;"
         } [x])).split(/\r?\n/g).slice(1, -1).map(r => r.split("\t").filter(w => w != ""))
-        c = ps.map(r => highlight(r[0]))
+        c = ps.map(r => r[0])
+        h = c.map(highlight)
         e = ps.map(r => r[1])
         isprim = ps.map(r => r[2] == "Primitive")
-        rankpoly = ps.map(r => Object({true: "<span class=\"emoji\">✅</span> rank-polymorphic", false: "<span class=\"emoji\">❌</span> not polymorphic", irrelevant: "<span class=\"emoji\">➖</span> N/A"})[r[4]])
-        experimental = ps.map(r => r[8] == "true" ? "<span class=\"emoji\">🧪</span> experimental" : "")
+        rankpoly = ps.map(r => Object({true: "<span class=\"noinv\">✅</span> rank-polymorphic", false: "<span class=\"noinv\">❌</span> not polymorphic", irrelevant: "<span class=\"noinv\">➖</span> N/A"})[r[4]])
+        experimental = ps.map(r => r[8] == "true" ? "<span class=\"noinv\">🧪</span> experimental" : "")
         p = d.split(/\r?\n/g).slice(1, -1).map(x => x.toLowerCase().replace(/http\S+\t/, "(>)").replace(/http\S+$/, "(?)"))
         r = ""
         for (var i = 0; i < c.length; i++) {
 	    // console.log(e[i])
-            r += `<tr><td>${c[i]}</td><td><a href="https://www.uiua.org/docs/${encodeURIComponent(c[i])}"/></td><td>${e[i]}</td><td>${rankpoly[i]}</td><td>${experimental[i]}</td></tr>`
+            r += `<tr><td>${h[i]}</td><td><a href="https://www.uiua.org/docs/${encodeURIComponent(c[i])}"/></td><td>${e[i]}</td><td>${rankpoly[i]}</td><td>${experimental[i]}</td></tr>`
         }
         t.innerHTML = r
         F(Q(q.value = s.get("q")))


### PR DESCRIPTION
a few changes:
1. the uiua pad uses a different color for strings on light mode vs dark mode to improve contrast, so i implemented it here too.
2. the chained `.replace` implementation of `highlight` which i wrote in #3 could lead to bugs where a span is highlighted by multiple rules, and it makes the order of the replace calls sneakily important. i refactored it to use one regex with named capturing groups, which makes the code a little shorter and may or may not make it more readable, but more importantly eliminates the possibility of a bug like that.
3. when i added highlighting, i accidentally introduced a bug with the documentation link feature, where the docs url would include the html for the highlighted code in it. this fixes that, although there is still a small bug which seems to have been there before #3 and i didn't feel like fixing yet, where escaped characters `"&'<>` are still put in the url as html entities like `&lt;`.

also, i renamed `.emoji` to `.noinv`.